### PR TITLE
Multiple App Service Placement "For" Loop

### DIFF
--- a/src/yafs/core.py
+++ b/src/yafs/core.py
@@ -1057,7 +1057,7 @@ class Sim:
         Creating initial deploy of services
         """
         for place in self.placement_policy.itervalues():
-	    	for app_name in place["apps"]:
+			for app_name in place["apps"]:
             	place["placement_policy"].initial_allocation(self, app_name)  # internally consideres the apps in charge
 
         """

--- a/src/yafs/core.py
+++ b/src/yafs/core.py
@@ -1057,7 +1057,7 @@ class Sim:
         Creating initial deploy of services
         """
         for place in self.placement_policy.itervalues():
-			for app_name in place["apps"]:
+	    	for app_name in place["apps"]:
             	place["placement_policy"].initial_allocation(self, app_name)  # internally consideres the apps in charge
 
         """

--- a/src/yafs/core.py
+++ b/src/yafs/core.py
@@ -1057,7 +1057,8 @@ class Sim:
         Creating initial deploy of services
         """
         for place in self.placement_policy.itervalues():
-            place["placement_policy"].initial_allocation(self, app_name)  # internally consideres the apps in charge
+			for app_name in place["apps"]:
+            	place["placement_policy"].initial_allocation(self, app_name)  # internally consideres the apps in charge
 
         """
         A internal DES process to stop the simulation,

--- a/src/yafs/core.py
+++ b/src/yafs/core.py
@@ -1057,7 +1057,7 @@ class Sim:
         Creating initial deploy of services
         """
         for place in self.placement_policy.itervalues():
-			for app_name in place["apps"]:
+	    for app_name in place["apps"]:
             	place["placement_policy"].initial_allocation(self, app_name)  # internally consideres the apps in charge
 
         """


### PR DESCRIPTION
I added a for loop to the .initial_allocation() method call in line 1060 of core.py. This was meant to address a problem we were having where the Placement policy initial_allocation(self,sim,app_name) method override would only take in the last app_name. This is because it was using the same iterable from the Population policy initial allocation for loop. Because of this, if you tried to simulate multiple apps with different services, you would only see the first app_name (Sim.deploy_app would append placement policies from new apps at the front). By adding this for loop, we were able to simulate multiple apps using multiple services. I hope this is helpful.